### PR TITLE
Use int64 explicitly for integer metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,10 +106,10 @@ func mustNodeAsFloat(d *html.Node) float64 {
 	}
 	return floatData
 }
-func mustNodeAsInt(d *html.Node) int {
+func mustNodeAsInt(d *html.Node) int64 {
 	data := strings.Replace(d.FirstChild.Data, "QAM", "", 1)
 	data = strings.Split(data, " ")[0]
-	intData, err := strconv.Atoi(data)
+	intData, err := strconv.ParseInt(data, 10, 64)
 	if err != nil {
 		panic("bad HTML node from modem")
 	}
@@ -122,21 +122,21 @@ type modemData struct {
 }
 
 type downstreamData struct {
-	DCID           int
+	DCID           int64
 	Freq           float64
 	Power          float64
 	SNR            float64
-	Modulation     int
-	Octets         int
-	Correcteds     int
-	Uncorrectables int
+	Modulation     int64
+	Octets         int64
+	Correcteds     int64
+	Uncorrectables int64
 }
 
 type upstreamData struct {
-	UCID        int
+	UCID        int64
 	Freq        float64
 	Power       float64
 	ChannelType string
-	SymbolRate  int
-	Modulation  int
+	SymbolRate  int64
+	Modulation  int64
 }

--- a/collector.go
+++ b/collector.go
@@ -174,7 +174,7 @@ func (m *ModemCollector) collect() error {
 	}
 	for id, node := range data.ds {
 		downstreamID := strconv.Itoa(id + 1)
-		downstreamDCID := strconv.Itoa(node.DCID)
+		downstreamDCID := strconv.FormatInt(node.DCID, 10)
 		m.DownstreamSNR.WithLabelValues(downstreamID, downstreamDCID).Set(node.SNR)
 		m.DownstreamFreq.WithLabelValues(downstreamID, downstreamDCID).Set(node.Freq)
 		m.DownstreamPower.WithLabelValues(downstreamID, downstreamDCID).Set(node.Power)
@@ -186,7 +186,7 @@ func (m *ModemCollector) collect() error {
 
 	for id, node := range data.us {
 		upstreamID := strconv.Itoa(id + 1)
-		upstreamUCID := strconv.Itoa(node.UCID)
+		upstreamUCID := strconv.FormatInt(node.UCID, 10)
 
 		m.UpstreamFreq.WithLabelValues(upstreamID, upstreamUCID).Set(node.Freq)
 		m.UpstreamPower.WithLabelValues(upstreamID, upstreamUCID).Set(node.Power)


### PR DESCRIPTION
This keeps the exporter from panicing on 32-bit systems, where
modem metrics may overflow Itoa().